### PR TITLE
Fix the branch reference in version_update.yml

### DIFF
--- a/.github/workflows/version_update.yml
+++ b/.github/workflows/version_update.yml
@@ -46,6 +46,6 @@ jobs:
           gh pr list
 
           if [[ $(gh pr list -H "${UPDATE_BRANCH}" | grep "${UPDATE_BRANCH}" | wc -l) -eq 0 ]]; then
-            gh pr create -B main -H ${UPDATE_BRANCH} --title "${TITLE}" --body "Automatic updated of sonar-scanner version value. Needs to be tagged for release."
+            gh pr create -B master -H ${UPDATE_BRANCH} --title "${TITLE}" --body "Automatic updated of sonar-scanner version value. Needs to be tagged for release."
           fi  
 

--- a/.github/workflows/version_update.yml
+++ b/.github/workflows/version_update.yml
@@ -1,5 +1,6 @@
 name: sonar-scanner version check
 on:
+  workflow_dispatch:
   schedule:
     - cron: '15 10 * * *'
 

--- a/.github/workflows/version_update.yml
+++ b/.github/workflows/version_update.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: master
           persist-credentials: true
           fetch-depth: 0
 


### PR DESCRIPTION
Since the manual run of the workflow was not enabled, it can't be triggered manually to be tested in this branch. This will be possible after the merge due to the new trigger on `workflow_dispatch`
`