### PR TITLE
update the cfamily examples url in the readme to point to SonarQube e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ env:
   SONAR_ROOT_CERT: ${{ secrets.SONAR_ROOT_CERT }}
 ```
 
-See also [example configurations](https://github.com/sonarsource-cfamily-examples?q=gh-actions-sc&type=all&language=&sort=)
+See also [example configurations](https://github.com/search?q=org%3Asonarsource-cfamily-examples+gh-actions-sq&type=repositories)
 
 ### Secrets and environment variables
 


### PR DESCRIPTION
…xamples instead of SonarCloud ones. In the results, remove popular repos and show only sq repos.

