### PR TITLE
fix: sanitize SONAR_HOST_URL for build-wrapper download path

### DIFF
--- a/scripts/configure_paths.sh
+++ b/scripts/configure_paths.sh
@@ -45,7 +45,7 @@ echo "sonar-scanner-dir=${SONAR_SCANNER_DIR}"
 echo "sonar-scanner-bin=${SONAR_SCANNER_DIR}/bin/${SONAR_SCANNER_NAME}"
 
 BUILD_WRAPPER_DIR="${INSTALL_PATH}/build-wrapper-${BUILD_WRAPPER_SUFFIX}"
-echo "build-wrapper-url=${SONAR_HOST_URL}/static/cpp/build-wrapper-${BUILD_WRAPPER_SUFFIX}.zip"
+echo "build-wrapper-url=${SONAR_HOST_URL%/}/static/cpp/build-wrapper-${BUILD_WRAPPER_SUFFIX}.zip"
 echo "build-wrapper-dir=${BUILD_WRAPPER_DIR}"
 echo "build-wrapper-bin=${BUILD_WRAPPER_DIR}/${BUILD_WRAPPER_NAME}"
 


### PR DESCRIPTION
When copying URLs they usually end with a trailing slash. In case of the SONAR_HOST_URL variable, this leads to a failure in downloading the build-wrapper.
Thus, this PR removes the trailing slash on SONAR_HOST_URL variable if present to sanitize the user input before using it.

