### PR TITLE
docs: remove duplicated space

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0
-    - name:  Install sonar-scanner and build-wrapper
+    - name: Install sonar-scanner and build-wrapper
       uses: sonarsource/sonarqube-github-c-cpp@v1
       env:
         SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}


### PR DESCRIPTION
Same as SonarSource/sonarcloud-github-c-cpp#38.

One can say that this PR just removes a single space. But this change has an impact! Because of this change (approximately) _millions_ of e-mails about failing yamllint will not be sent to users, who just copied and pasted the example workflow.