### PR TITLE
fix: prevent globbing and word splitting

### DIFF
--- a/scripts/create_install_path.sh
+++ b/scripts/create_install_path.sh
@@ -15,7 +15,7 @@ fi
 ABSOLUTE_INSTALL_PATH=$(realpath "${INSTALL_PATH}")
 echo "Absolute installation path is '${ABSOLUTE_INSTALL_PATH}'"
 
-test  -d ${INSTALL_PATH}
+test -d "${INSTALL_PATH}"
 check_status "Installation path '${INSTALL_PATH}' is not a directory (absolute path is '${ABSOLUTE_INSTALL_PATH}')"
 
 test -r "${INSTALL_PATH}"


### PR DESCRIPTION
Not using double quotes here might cause _globbing and word splitting_ (cf. [SC2086](https://www.shellcheck.net/wiki/SC2086)). Please compare the edited line with the other ones starting with `test`.

Same as SonarSource/sonarcloud-github-c-cpp#60.